### PR TITLE
fix: use the new repo url

### DIFF
--- a/cloudformation.template
+++ b/cloudformation.template
@@ -55,7 +55,7 @@
             "#!/bin/bash -ex",
             "sudo yum update",
             "sudo yum install git -y",
-            "git clone https://github.com/nalbion/oracle-lambda-test"
+            "git clone https://github.com/nalbion/node-oracledb-lambda-test"
           ]]}
         }
       }


### PR DESCRIPTION
repo url to clone is now: https://github.com/nalbion/node-oracledb-lambda-test
